### PR TITLE
Adding colspan to hide background

### DIFF
--- a/src/components/Route.js
+++ b/src/components/Route.js
@@ -87,7 +87,7 @@ class Routes extends Component {
                     <th>Departure Place</th>
                     <th>Arrival Place</th>
                     <th>Means of Travel</th>
-                    <th>Transit Time</th>
+                    <th colSpan="4">Transit Time</th>
                 </tr>,
 
                 <Segment

--- a/src/components/Segment.js
+++ b/src/components/Segment.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 class Segment extends Component {
-    
+
 
     render() {
         return (
@@ -11,8 +11,10 @@ class Segment extends Component {
                         <td className="tabledata-style">{this.props.places[segment.depPlace].shortName}</td>
                         <td className="tabledata-style">{this.props.places[segment.arrPlace].shortName}</td>
                         <td className="tabledata-style">{this.props.vehicles[segment.vehicle].name}</td>
-                        <td className="tabledata-style">{this.props.minutesToHours(segment.transitDuration)}</td>
-                    </tr>  
+                        <td
+                          className="tabledata-style"
+                          colSpan="4">{this.props.minutesToHours(segment.transitDuration)}</td>
+                    </tr>
                 ]
                 )
             })


### PR DESCRIPTION
- **Ser bättre ut?** La till så att de sista kolumnerna tar upp 4 kolumner istället för bara 1. På så sätt så döljs den gula bakgrunden
- CSS:en buggar sig fortfarande och stajlar inte längre tabellen med rundade hörn osv. Har ingen aning om varför :neutral_face: 