### PR TITLE
Responsive fixes - WIP

### DIFF
--- a/src/components/Route.js
+++ b/src/components/Route.js
@@ -69,7 +69,7 @@ class Routes extends Component {
                 {this.props.departurePlace.shortName}
             </td>
             <td>{this.props.arrivalPlace.shortName} </td>
-            <td>{this.getVehicleList()}</td>
+            <td className="hidden">{this.getVehicleList()}</td>
             <td><time datetime={`${this.props.durationMinutes}M`}>{this.props.durationHours}</time></td>
             <td>{this.props.price + " " + this.props.currency}</td>
             <td className="hidden">{this.props.segments.length}</td>

--- a/src/components/Route.js
+++ b/src/components/Route.js
@@ -73,14 +73,14 @@ class Routes extends Component {
             <td><time datetime={`${this.props.durationMinutes}M`}>{this.props.durationHours}</time></td>
             <td>{this.props.price + " " + this.props.currency}</td>
             <td className="hidden">{this.props.segments.length}</td>
-            <td className="google-map-icon"><img
+            <td className="google-map- hidden"><img
                             alt="Google map icon"
-                            title="Map Icon" 
+                            title="Map Icon"
                             onClick={()=>{
                               let map = document.getElementById("map")
                               map.scrollIntoView({behavior: "smooth", inline: "nearest"});
 
-                        }} src="\images\icons\googlemaps.png"></img></td>
+                        }} src="/images/icons/googlemaps.png"></img></td>
         </tr>)
 
         if (this.state.expandMode === false) {

--- a/src/components/Route.js
+++ b/src/components/Route.js
@@ -71,7 +71,12 @@ class Routes extends Component {
             <td>{this.props.arrivalPlace.shortName} </td>
             <td className="hidden">{this.getVehicleList()}</td>
             <td><time datetime={`${this.props.durationMinutes}M`}>{this.props.durationHours}</time></td>
-            <td>{this.props.price + " " + this.props.currency}</td>
+            <td>
+              {this.props.price + " "}
+              <span className="hidden">
+                {this.props.currency}
+              </span>
+            </td>
             <td className="hidden">{this.props.segments.length}</td>
             <td className="google-map- hidden"><img
                             alt="Google map icon"

--- a/src/components/Route.js
+++ b/src/components/Route.js
@@ -70,7 +70,7 @@ class Routes extends Component {
             </td>
             <td>{this.props.arrivalPlace.shortName} </td>
             <td>{this.getVehicleList()}</td>
-            <td>{this.props.durationHours}</td>
+            <td><time datetime={`${this.props.durationMinutes}M`}>{this.props.durationHours}</time></td>
             <td>{this.props.price + " " + this.props.currency}</td>
             <td className="hidden">{this.props.segments.length}</td>
             <td className="google-map-icon"><img

--- a/src/components/RouteMap.js
+++ b/src/components/RouteMap.js
@@ -25,7 +25,7 @@ constructor(props){
 changeAnimationDep(){
 
   this.state.animationValueDep===1 ? this.setState({animationValueDep:0}) : this.setState({animationValueDep:1})
-  
+
 
 }
 changeAnimationArr(){
@@ -53,8 +53,8 @@ changeAnimationArr(){
           <GoogleMap
             id="example-map"
             mapContainerStyle={{
-              height: "25em",
-              width: "45em"
+              height: "20em",
+              width: "30em"
             }}
             center={stockholm}
             zoom={3}
@@ -98,7 +98,7 @@ function getArrival(route){
   route.segments.map(segment => {
 
       arrival = new Coordinates(route.places[segment.arrPlace].lat, route.places[segment.arrPlace].lng);
-  
+
     })
     return arrival;
 }
@@ -130,6 +130,3 @@ function getPosition(route) {
 
 
 export default RouteMap;
-
-
-

--- a/src/components/SearchForm.js
+++ b/src/components/SearchForm.js
@@ -7,10 +7,11 @@ const SearchForm = (props) => (
     <aside>
         <form onSubmit={props.submitSearch}>
             <div>
-                <fieldset>
-                    <img src="images/icons/search.svg"
-                        alt="Magnifying glass"
-                        title="Search" />
+                <fieldset className="search-field">
+                <legend><img src="images/icons/search.svg"
+                    alt="Magnifying glass"
+                    title="Search" /></legend>
+
                     <input className="cities input-style"
                         list="cities"
                         type="search"
@@ -52,8 +53,8 @@ const SearchForm = (props) => (
                         <option value="Aare">Åre</option>
                         <option value="Falun">Falun</option>
                     </select>
-
                     <select className="select-field" onChange={props.handleCurrency}>
+                        <option value="USD">--Please select a currency--</option>
                         <option value="USD">USD</option>
                         <option value="SEK">SEK</option>
                         <option value="EUR">EURO</option>
@@ -63,19 +64,25 @@ const SearchForm = (props) => (
 
             <div className="departure-home-container">
                 <fieldset className="departure-home">
-                    <legend>Departure date</legend>
+                    <legend>
+                      <img src="images/icons/calendar.svg"
+                          alt="Departure date"
+                          title="Choose date" />
+                          Departure date
+                    </legend>
                     <input type="date" className="input-style" onChange={props.handleDeparture} />
-                    <img src="images/icons/calendar.svg"
-                        alt="Departure date"
-                        title="Choose date" />
+
                 </fieldset>
 
                         <fieldset className="departure-home">
-                            <legend>Return date</legend>
+                            <legend>
+                              <img src="images/icons/calendar.svg"
+                                  alt="Going home date"
+                                  title="Choose date" />
+                                  Return date
+                            </legend>
                             <input type="date" className="input-style" onChange={props.handleReturn} />
-                            <img src="images/icons/calendar.svg"
-                                alt="Going home date"
-                                title="Choose date" />
+
                         </fieldset>
                     </div>
                     <div className="filter-container">

--- a/src/components/SearchResults.js
+++ b/src/components/SearchResults.js
@@ -71,6 +71,7 @@ class SearchResults extends Component {
         )
       })
     return (
+
       <article className="center-results">
         <table className="result-table">
           <caption className="search-caption">Search results</caption>
@@ -78,19 +79,28 @@ class SearchResults extends Component {
             <tr>
               <th>From</th>
               <th>To</th>
-              <th>Means of Travel</th>
+              <th className="hidden">Means of Travel</th>
               <th
                 onClick={() => this.setColumnState('time')} >Time
-                <SortArrows name="time" sortColumn={this.state.sortColumn} sortAscending={this.state.sortAscending} />
+                <SortArrows
+                  name="time"
+                  sortColumn={this.state.sortColumn}
+                  sortAscending={this.state.sortAscending} />
               </th>
               <th
                 onClick={() => this.setColumnState('price')} >Price
-                <SortArrows name="price" sortColumn={this.state.sortColumn} sortAscending={this.state.sortAscending} />
+                <SortArrows
+                  name="price"
+                  sortColumn={this.state.sortColumn}
+                  sortAscending={this.state.sortAscending} />
               </th>
               <th
                 onClick={() => this.setColumnState('transits')}
                 className="hidden">Transits
-                <SortArrows name="transits" sortColumn={this.state.sortColumn} sortAscending={this.state.sortAscending} />
+                <SortArrows
+                  name="transits"
+                  sortColumn={this.state.sortColumn}
+                  sortAscending={this.state.sortAscending} />
               </th>
               <th className="hidden">
                 Map

--- a/src/components/Segment.js
+++ b/src/components/Segment.js
@@ -6,9 +6,13 @@ const Segment = (props) => (
 <td>{props.places[props.depPlace].shortName}</td>
 <td>{props.places[props.arrPlace].shortName}</td>
 <td>{props.capitalizeFirstLetter(props.vehicles[props.vehicle].name)}</td>
-<td colSpan="4">{props.minutesToHours(props.transitDuration)}</td>
+<td colSpan="4">
+  <time datetime={`${props.durationMinutes}M`}>
+    {props.minutesToHours(props.transitDuration)}
+  </time>
+</td>
 </tr>
 
-) 
+)
 
 export default Segment

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -14,9 +14,6 @@
   }
 
   /* search results-table */
-  .result-table {
-  }
-
 
   .searchResults th {
       font-size: 0.8em;
@@ -25,11 +22,7 @@
   .searchResults td {
       font-size: 0.8em;
       padding: 0.2em;
-      border: 1px solid grey;
-  }
-
-  .searchResults-border td {
-    border: 1px solid grey;
+      border: 1px solid #d3d3d3;
   }
 
 

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -13,6 +13,20 @@
 
   }
 
+  /* search results-table */
+  .searchResults {
+  }
+
+  .searchResults th {
+      font-size: 0.7em;
+      padding-right: 0;
+  }
+
+  .searchResults td {
+      font-size: 0.5em;
+  }
+
+
 }
 @media only screen and (max-width: 999px) {
   .icon {

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -14,16 +14,22 @@
   }
 
   /* search results-table */
-  .searchResults {
+  .result-table {
   }
 
+
   .searchResults th {
-      font-size: 0.7em;
-      padding-right: 0;
+      font-size: 0.8em;
   }
 
   .searchResults td {
-      font-size: 0.5em;
+      font-size: 0.8em;
+      padding: 0.2em;
+      border: 1px solid grey;
+  }
+
+  .searchResults-border td {
+    border: 1px solid grey;
   }
 
 


### PR DESCRIPTION
# Mobile only changes
Major changes to result-table on mobile version:

- (`Means of transport`) is not displayed unless the row is expanded.
- Reduced font-size
- Reduced padding
- Adding grey border between `<td>` for increased visibility

# Changes on both versions
Moved calendar and magnifying glass icons to `<legend>`

# 2do:
- Google Map is **not** responsive (horizontal scroll bar)
- Select currency field gets pushed down to the line beneath on mobile and thus looks awful