### PR TITLE
Made the Google map responsive in turn removing the side scrollbar

### DIFF
--- a/src/components/RouteMap.js
+++ b/src/components/RouteMap.js
@@ -53,8 +53,8 @@ changeAnimationArr(){
           <GoogleMap
             id="example-map"
             mapContainerStyle={{
-              height: "20em",
-              width: "30em"
+              height: "60vh",
+              width: "80vw"
             }}
             center={stockholm}
             zoom={3}


### PR DESCRIPTION
Changed the values for width and height for the GoogleMap from em to vh and vw, respectively, which makes the map responsive and consequently removes the side scrollbar.